### PR TITLE
Use real note purchase agreement data.

### DIFF
--- a/components/NotePurchaseAgreementViewer.tsx
+++ b/components/NotePurchaseAgreementViewer.tsx
@@ -1,27 +1,38 @@
 import { StyleSheet } from "react-native";
 
 import { useEffect, useState } from "react";
+import { useParams } from "react-router-native"
+import * as SplashScreen from 'expo-splash-screen';
+
 import { default as PdfViewer } from "../components/PdfViewer";
 import useNoteServiceAgreement from "../hooks/useNoteServiceAgreement";
 import { View } from "./Themed";
 
 export default function NotePurchaseAgreementViewer({ navigation }: any) {
+  const {notePurchaseAgreementId} = useParams()
   const [doc, setDoc] = useState<Buffer>();
+  const [isLoadingComplete, setLoadingComplete] = useState(false);
+
   const functions = useNoteServiceAgreement();
 
   useEffect(() => {
     (async () => {
-      const doc = (await functions.getNotePurchaseAgreementDoc()) as Buffer;
+      SplashScreen.preventAutoHideAsync();
+      if (!notePurchaseAgreementId) return
+      const doc = (await functions.getNotePurchaseAgreementDoc(notePurchaseAgreementId)) as Buffer;
 
       setDoc(doc);
+      setLoadingComplete(true);
+      await SplashScreen.hideAsync()
     })();
   }, []);
 
   return (
     <View style={{ flex: 1 }}>
-      <View style={{ flex: 1 }}>
+      {isLoadingComplete?
+      (<View style={{ flex: 1 }}>
         <PdfViewer doc={doc} />
-      </View>
+      </View>): null}
     </View>
   );
 }

--- a/functions/functions/navigation.ts
+++ b/functions/functions/navigation.ts
@@ -20,4 +20,7 @@ export default {
   *openStatementScreen() {
     yield cmds.call(navigate, routes.STATEMENT_VIEW_ROUTE);
   },
+  *openAgreementScreen(agreemendId: string) {
+    yield cmds.call(navigate, `${routes.NOTE_PURCHASE_AGREEMENT_VIEW_ROUTE}/${agreemendId}`)
+  }
 } as IPropertyProsNavigationFunctions;

--- a/functions/functions/notePurchaseAgreement.ts
+++ b/functions/functions/notePurchaseAgreement.ts
@@ -1,26 +1,60 @@
 import { notePurchaseAgreement as sdk } from "property-pros-sdk";
+import { IPropertyProsAuthenticatedUserState } from "../../interface/interfaces";
 import { IPropertyProsFunctions } from "../../interface/IPropertyProsFunctions";
 import cmds from "../cmds";
+import { Alert } from 'react-native';
+import { GetNotePurchaseAgreementsResponse } from "property-pros-sdk/api/note_purchase_agreement/v1/note_purchase_agreement";
+import { notePurchaseAgreementDocClient } from "../handlers/propertyProsSDK";
+import { Metadata } from "nice-grpc-common";
+
 
 export default {
-  *getNotePurchaseAgreementDoc(notePurchaseAgreementPayload: any): Generator<
-    Generator<never, sdk.GetNotePurchaseAgreementDocResponse | Buffer, unknown>,
-    Buffer,
-    Buffer | sdk.GetNotePurchaseAgreementDocResponse
-  > {
+  *getNotePurchaseAgreements(){
+    console.log("here in getNotePurchaseAgreements")
+    const {
+      isAuthenticated,
+      authToken
+    }: IPropertyProsAuthenticatedUserState = yield cmds.reduxGetState("authenticatedUser");
+    if (!isAuthenticated) {
+      Alert.alert("You are currently not signed in, please signin!")
+      return
+    }
+    let metadata = new Metadata({});
+    metadata.set("authorization", authToken!);
+
+    let response:GetNotePurchaseAgreementsResponse;
+    try {
+      response = yield cmds.callFn(notePurchaseAgreementDocClient.getNotePurchaseAgreements, 
+        {},
+        { metadata })
+      } catch(err) {
+        Alert.alert("Failed to fetch data, Please try again!")
+        return
+      }
+
+      return response
+  },
+
+  *getNotePurchaseAgreementDoc(notePurchaseAgreementId: any) {
+    const {
+      isAuthenticated,
+      authToken
+    }: IPropertyProsAuthenticatedUserState = yield cmds.reduxGetState("authenticatedUser");
+    if (!isAuthenticated) {
+      Alert.alert("You are currently not signed in, please signin!")
+      return
+    }
+
+    let metadata = new Metadata({});
+    
+    metadata.set("authorization", authToken!);
     const response = <sdk.GetNotePurchaseAgreementDocResponse>(
-      yield cmds.getNotePurchaseAgreementDoc({
+      yield cmds.callFn(notePurchaseAgreementDocClient.getNotePurchaseAgreementDoc,{
         payload: {
-          DateOfBirth: "12/21/1990",
-          EmailAddress: "test@test.com",
-          FirstName: "fugiat",
-          FundsCommitted: 378109,
-          HomeAddress: "est",
-          LastName: "dolor Duis",
-          PhoneNumber: "in",
-          SocialSecurity: "laboris elit incididunt commodo pariatur",
+          id: notePurchaseAgreementId,
         },
-      })
+      },
+      {metadata})
     );
 
     return <Buffer>(

--- a/hooks/useNavigation.ts
+++ b/hooks/useNavigation.ts
@@ -15,6 +15,7 @@ export default (): IPropertyProsNavigationHelper => {
     openSignUpScreen: functions.openSignUpScreen,
     openDashboardScreen: functions.openDashboardScreen,
     openStatementScreen: functions.openStatementScreen,
+    openAgreementScreen: functions.openAgreementScreen,
     setChangeRoute: functions.setChangeRoute,
   };
 

--- a/hooks/useNoteServiceAgreement.ts
+++ b/hooks/useNoteServiceAgreement.ts
@@ -6,5 +6,6 @@ export default (): IPropertyProsNotePurchaseAgreementFunctions => {
 
   return {
     getNotePurchaseAgreementDoc: functions.getNotePurchaseAgreementDoc,
+    getNotePurchaseAgreements: functions.getNotePurchaseAgreements,
   };
 };

--- a/interface/IPropertyProsFunctions.d.ts
+++ b/interface/IPropertyProsFunctions.d.ts
@@ -11,7 +11,9 @@ interface IPropertyProsFunctions
   openSignInScreen(): Promise<void> | Generator<never, void, unknown>;
   openSignUpScreen(): Promise<void> | Generator<never, void, unknown>;
   openDashboardScreen(): Promise<void> | Generator<never, void, unknown>;
+  openDashboardScreen(): Promise<void> | Generator<never, void, unknown>;
   openStatementScreen(): Promise<void> | Generator<never, void, unknown>;
+  openAgreementScreen(agreemendId): Promise<void> | Generator<never, void, unknown>;
   setChangeRoute(
     changeRoute: boolean
   ): Promise<void> | Generator<never, void, unknown>;
@@ -22,7 +24,9 @@ interface IPropertyProsFunctions
 }
 
 interface IPropertyProsNotePurchaseAgreementFunctions {
-  getNotePurchaseAgreementDoc(): Promise<Buffer> | Generator<never, Buffer, any>;
+  getNotePurchaseAgreementDoc(notePurchaseAgreementId: string): Promise<Buffer> | Generator<never, Buffer, any>;
+  getNotePurchaseAgreements(): Promise<sdk.GetNotePurchaseAgreementsResponse> | Generator<never, sdk.GetNotePurchaseAgreementsResponse, any>
+
 }
 
 interface IPropertyProsAuthenticatedUserFunctions {
@@ -72,5 +76,6 @@ interface IPropertyProsNavigationFunctions {
   openSignUpScreen(): Promise<void> | Generator<never, void, unknown>;
   openDashboardScreen(): Promise<void> | Generator<never, void, unknown>;
   openStatementScreen(): Promise<void> | Generator<never, void, unknown>;
+  openAgreementScreen(agreemendId: string): Promise<void> | Generator<never, void, unknown>;
   setChangeRoute(boolean): Promise<void> | Generator<never, void, unknown>;
 }

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -48,6 +48,10 @@ export default function navigation() {
           path={NOTE_PURCHASE_AGREEMENT_VIEW_ROUTE}
           element={<ScreenWrapper component={NotePurchaseAgreementViewer} />}
         />
+        <Route
+          path={`${NOTE_PURCHASE_AGREEMENT_VIEW_ROUTE}/:notePurchaseAgreementId`}
+          element={<ScreenWrapper component={NotePurchaseAgreementViewer} />}
+        />
         <Route path="*" element={<Navigate to={SIGN_IN_ROUTE} />} />
       </Routes>
     </NativeRouter>


### PR DESCRIPTION
This PR adds Real note purchase Agreement data, created during registration, and show the PDF corresponding to the data saved.

The Docker-compose for https://github.com/property-pros/property-pros-docs sometimes get stuck while startup at:
<img width="798" alt="Screenshot 2023-04-29 at 3 40 54 PM" src="https://user-images.githubusercontent.com/8309130/235325345-32d2a3e5-7314-4a6f-bc37-91bab4b5a67e.png">
hence I had connected my property-pros-service to a mock client locally, hence the resulting PDF in the video below.

https://user-images.githubusercontent.com/8309130/235325232-d7ad1eba-1b45-4958-8f6e-b1859992de4c.mp4

